### PR TITLE
Add `--uashield` flag for using targets provided by UAShield team.

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -9,7 +9,7 @@ import colorama
 from yarl import URL
 
 from src.cli import init_argparse
-from src.core import logger, cl, UDP_THREADS, LOW_RPC, IT_ARMY_CONFIG_URL
+from src.core import logger, cl, UDP_THREADS, LOW_RPC, IT_ARMY_CONFIG_URL, UASHIELD_CONFIG_URL
 from src.dns_utils import resolve_host, get_resolvable_targets
 from src.mhddos import main as mhddos_main
 from src.output import AtomicCounter, show_statistic, print_banner, print_progress
@@ -143,6 +143,8 @@ def start(args):
     total_threads = thread_pool.start(args.threads)  # It is possible that not all threads were started
     if args.itarmy:
         targets_iter = Targets([], IT_ARMY_CONFIG_URL)
+    elif args.uashield:
+        targets_iter = Targets([], UASHIELD_CONFIG_URL)
     else:
         targets_iter = Targets(args.targets, args.config)
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -80,4 +80,9 @@ def init_argparse() -> argparse.ArgumentParser:
         action='store_true',
         default=False,
     )
+    parser.add_argument(
+        '--uashield',
+        action='store_true',
+        default=False,
+    )
     return parser

--- a/src/core.py
+++ b/src/core.py
@@ -12,6 +12,7 @@ ROOT_DIR = Path(__file__).parent.parent
 
 PROXIES_URL = 'https://raw.githubusercontent.com/porthole-ascend-cinnamon/proxy_scraper/main/proxies.txt'
 IT_ARMY_CONFIG_URL = 'https://gist.githubusercontent.com/ddosukraine2022/f739250dba308a7a2215617b17114be9/raw/mhdos_targets_tcp.txt'
+UASHIELD_CONFIG_URL = 'https://cdn.uashield.cc/sites.txt'
 
 PROXY_TIMEOUT = 5
 UDP_THREADS = 1


### PR DESCRIPTION
**UA Cyber SHIELD** team provides a list of targets and proxies compatible with MHDDos Proxy: 
- https://cdn.uashield.cc/sites.txt
- https://cdn.uashield.cc/proxies.txt

The pull request contains just a `--uashield` flag as a shorthand for using MHDDos with UAShield targets. Just like it's already implemented for IT Army team targets: https://github.com/porthole-ascend-cinnamon/mhddos_proxy/blob/main/src/core.py#L14