### PR TITLE
Workaround for TLS handshake failures

### DIFF
--- a/src/mhddos.py
+++ b/src/mhddos.py
@@ -31,6 +31,7 @@ from .referers import REFERERS
 ctx: SSLContext = create_default_context()
 ctx.check_hostname = False
 ctx.verify_mode = CERT_NONE
+ctx.set_ciphers("DEFAULT")
 
 __version__: str = "2.4 SNAPSHOT"
 __ip__: Any = None


### PR DESCRIPTION
Connection to some hosts with SSL encryption fails because of old TLS versions & insecure ciphers on Python3.10+ because it has stronger security guarantees for TLS protocol ciphers. Details could be found here: https://bugs.python.org/issue43998 

The change reverts cipher settings to default, as we don't care much about outdated implementation of the target.