### PR TITLE
Config file to support multiple methods

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -81,10 +81,12 @@ def run_ddos(thread_pool, proxies, targets, total_threads, period, rpc, http_met
         elif target.url.scheme == "tcp":
             params_list.append(Params(target, 'TCP', threads_per_target))
         # HTTP(S), methods from --http-methods
-        else:
+        elif target.url.scheme in {"http", "https"}:
             threads = threads_per_target // len(http_methods)
             for method in http_methods:
                 params_list.append(Params(target, method, threads))
+        else:
+            raise ValueError(f"Unsupported scheme given: {target.url.scheme}")
 
     logger.info(f'{cl.YELLOW}Запускаємо атаку...{cl.RESET}')
     statistics = {}

--- a/runner.py
+++ b/runner.py
@@ -71,15 +71,15 @@ def run_ddos(thread_pool, proxies, targets, total_threads, period, rpc, http_met
     params_list = []
     for target in targets:
         assert target.is_resolved, "Unresolved target cannot be used for attack"
-        # UDP
+        # udp://, method defaults to "UDP"
         if target.is_udp:
             params_list.append(Params(target, target.method or 'UDP', UDP_THREADS))
-
-        # TCP
-        elif target.url.scheme == "tcp" or target.method is not None:
-            params_list.append(
-                Params(target, target.method or 'TCP', threads_per_target))
-
+        # Method is given explicitly
+        elif target.method is not None:
+            params_list.append(Params(target, target.method, threads_per_target))
+        # tcp://
+        elif target.url.scheme == "tcp":
+            params_list.append(Params(target, 'TCP', threads_per_target))
         # HTTP(S), methods from --http-methods
         else:
             threads = threads_per_target // len(http_methods)

--- a/src/dns_utils.py
+++ b/src/dns_utils.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor
 from functools import lru_cache
 from typing import List, Optional
 
@@ -34,7 +34,7 @@ def safe_resolve_host(host: str) -> Optional[str]:
         return None
 
 
-def resolve_all_targets(targets: List[Target], thread_pool: ThreadPoolExecutor) -> List[Target]:
+def resolve_all_targets(targets: List[Target], thread_pool: Executor) -> List[Target]:
     unresolved_hosts = list(set(target.url.host for target in targets if not target.is_resolved))
     ips = dict(zip(unresolved_hosts, thread_pool.map(safe_resolve_host, unresolved_hosts)))
     for target in targets:

--- a/src/output.py
+++ b/src/output.py
@@ -38,26 +38,25 @@ def show_statistic(statistics, refresh_rate, table, vpn_mode, proxies_cnt, perio
     tabulate_text = []
     total_pps = 0
     total_bps = 0
-    for k in statistics:
-        counters = statistics[k]
+    for params, counters in statistics.items():
         pps = int(counters['requests'].reset() / refresh_rate)
         total_pps += pps
         bps = int(8 * counters['bytes'].reset() / refresh_rate)
         total_bps += bps
         if table:
             tabulate_text.append((
-                f'{cl.YELLOW}%s' % k.url.host, k.url.port, k.method,
-                k.threads, Tools.humanformat(pps), f'{Tools.humanbits(bps)}{cl.RESET}'
+                f'{cl.YELLOW}%s' % params.target.url.host, params.target.url.port, params.method,
+                params.threads, Tools.humanformat(pps), f'{Tools.humanbits(bps)}{cl.RESET}'
             ))
         else:
             logger.info(
                 f'{cl.YELLOW}Ціль:{cl.BLUE} %s,{cl.YELLOW} Порт:{cl.BLUE} %s,{cl.YELLOW} Метод:{cl.BLUE} %s{cl.YELLOW}'
                 f' Потоків:{cl.BLUE} %s{cl.YELLOW} PPS:{cl.BLUE} %s,{cl.YELLOW} BPS:{cl.BLUE} %s{cl.RESET}' %
                 (
-                    k.url.host,
-                    k.url.port,
-                    k.method,
-                    k.threads,
+                    params.target.url.host,
+                    params.target.url.port,
+                    params.method,
+                    params.threads,
                     Tools.humanformat(pps),
                     Tools.humanbits(bps),
                 )

--- a/src/targets.py
+++ b/src/targets.py
@@ -1,9 +1,8 @@
 from .core import logger, cl
 from .system import read_or_fetch
 
-from dataclasses import dataclass
-from typing import List, Optional, Tuple
-import urllib
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 from yarl import URL
 
@@ -12,7 +11,7 @@ from yarl import URL
 class Target:
     url: URL
     method: Optional[str] = None
-    params: Optional[List[Tuple[str, str]]] = None
+    params: Dict[str, str] = field(default_factory=dict)
     addr: Optional[str] = None
 
     @classmethod
@@ -21,7 +20,7 @@ class Target:
         n_parts = len(parts)
         url = Target.prepare_url(parts[0])
         method = parts[1].upper() if n_parts > 1 else None
-        params = urllib.parse.parse_qsl(parts[2]) if n_parts > 2 else None
+        params = dict(tuple(part.split("=")) for part in parts[2:])
         return cls(URL(url), method, params)
 
     @staticmethod

--- a/src/targets.py
+++ b/src/targets.py
@@ -4,6 +4,7 @@ from .system import read_or_fetch
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
+from dns import inet
 from yarl import URL
 
 
@@ -18,10 +19,11 @@ class Target:
     def from_string(cls, raw: str) -> "Target":
         parts = [part.strip() for part in raw.split(" ")]
         n_parts = len(parts)
-        url = Target.prepare_url(parts[0])
+        url = URL(Target.prepare_url(parts[0]))
         method = parts[1].upper() if n_parts > 1 else None
         params = dict(tuple(part.split("=")) for part in parts[2:])
-        return cls(URL(url), method, params)
+        addr = url.host if inet.is_address(url.host) else None
+        return cls(url, method, params, addr)
 
     @staticmethod
     def prepare_url(target: str) -> str:

--- a/src/targets.py
+++ b/src/targets.py
@@ -12,7 +12,7 @@ from yarl import URL
 class Target:
     url: URL
     method: Optional[str] = None
-    params: Dict[str, str] = field(default_factory=dict)
+    options: Dict[str, str] = field(default_factory=dict)
     addr: Optional[str] = None
 
     @classmethod
@@ -21,9 +21,9 @@ class Target:
         n_parts = len(parts)
         url = URL(Target.prepare_url(parts[0]))
         method = parts[1].upper() if n_parts > 1 else None
-        params = dict(tuple(part.split("=")) for part in parts[2:])
+        options = dict(tuple(part.split("=")) for part in parts[2:])
         addr = url.host if inet.is_address(url.host) else None
-        return cls(url, method, params, addr)
+        return cls(url, method, options, addr)
 
     @staticmethod
     def prepare_url(target: str) -> str:
@@ -45,6 +45,12 @@ class Target:
     @property
     def is_udp(self) -> bool:
         return self.url.scheme == "udp"
+
+    def option(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self.options.get(key, default)
+
+    def __hash__(self):
+        return hash((self.url, self.method))
 
 
 class Targets:

--- a/src/targets.py
+++ b/src/targets.py
@@ -20,7 +20,7 @@ class Target:
         parts = [part.strip() for part in raw.split(" ")]
         n_parts = len(parts)
         url = Target.prepare_url(parts[0])
-        method = parts[1] if n_parts > 1 else None
+        method = parts[1].upper() if n_parts > 1 else None
         params = urllib.parse.parse_qsl(parts[2]) if n_parts > 2 else None
         return cls(URL(url), method, params)
 

--- a/src/targets.py
+++ b/src/targets.py
@@ -1,19 +1,32 @@
 from .core import logger, cl
 from .system import read_or_fetch
 
-from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 from dns import inet
 from yarl import URL
 
 
-@dataclass
+Options = Dict[str, str]
+
+
 class Target:
     url: URL
-    method: Optional[str] = None
-    options: Dict[str, str] = field(default_factory=dict)
-    addr: Optional[str] = None
+    method: Optional[str]
+    options: Options
+    addr: Optional[str]
+
+    def __init__(
+        self,
+        url: URL,
+        method: Optional[str] = None,
+        options: Optional[Options] = None,
+        addr: Optional[str] = None
+    ):
+        self.url = url
+        self.method = method
+        self.options = options or {}
+        self.addr = addr
 
     @classmethod
     def from_string(cls, raw: str) -> "Target":
@@ -50,7 +63,7 @@ class Target:
         return self.options.get(key, default)
 
     def __hash__(self):
-        return hash((self.url, self.method))
+        return hash(id(self))
 
 
 class Targets:


### PR DESCRIPTION
Old configuration file format with "one line = one target" still works as is.

Now it's possible to specify per-target method. Config format also supports optional per-target configuration options encoded similar to URL parameters (form-urlencoded). When specified, they are parsed but are not propagated to mhddos calls (easy to add when there's a use case).

Example of the config file:

```
https://github.com:443 GET
https://github.com:443 POST
http://bitbucket.org:80 STRESS read_timeout=10 rpc=1024
tcp://104.192.141.1:80 TCP
tcp://104.192.141.1:22
https://bitbucket.org
```

The code to normalize URL is the same (e.g. when scheme is missing). The resolution order for the method is almost the same with the only caveat: if the method is provided explicitly in the config it's used instead of default.

Questions:
* right now, default scheme is "http", should it be "tcp"?
* with new file format it's possible to create duplicated target because of `--http-methods` parameter in CLI. Consider the following:

```
https://github.com:443 GET
https://github.com:443 POST
https://github.com:443
```

Running the script with `-c <CONFIG> --http-methods GET POST` results in the following resolution: 

1. https://github.com:443 with GET (per config)
2. https://github.com:443 with POST (per config)
3. https://github.com:443 with GET ("default" in config, per `--http-methods`)
4. https://github.com:443 with POST ("default" in config, per `--http-methods`)

Should we explicitly look for such situations are prevent them from happening?