### PR TITLE
Randomly select targets when threads limit is too low

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -300,8 +300,7 @@ async def run_ddos(
                     logger.warning(
                         f"{cl.MAGENTA}Завантажено порожній конфіг - буде використано попередній{cl.RESET}"
                     )
-
-                if targets and (changed or force_next):
+                elif (changed or force_next):
                     force_next = await install_targets(targets)
 
             except asyncio.CancelledError as e:

--- a/runner.py
+++ b/runner.py
@@ -205,13 +205,11 @@ async def run_ddos(
                 if num_allowed == 0:
                     # presumably this is going to be an extreme use case
                     raise RuntimeError("Capacity initialization error")
-
                 # we need free capacity to be able to scale-up for working targets
-                adjusted_capacity = 1
+                adjusted_capacity, force_install = 1, True
                 random.shuffle(tcp_flooders)
                 tcp_flooders = tcp_flooders[:num_allowed]
                 num_flooders = len(tcp_flooders)
-                force_install = True
                 logger.info(f"{cl.MAGENTA}Обрано {num_flooders} цілей для атаки{cl.RESET}")
 
             # adjust settings to avoid situation when we have just a few

--- a/runner.py
+++ b/runner.py
@@ -197,23 +197,26 @@ async def run_ddos(
 
         if tcp_flooders:
             num_flooders = len(tcp_flooders)
-            num_init = initial_capacity * num_flooders
+            adjusted_capacity = initial_capacity
+            num_init = adjusted_capacity * num_flooders
 
             if num_init > total_threads:
-                num_allowed = total_threads // initial_capacity
+                num_allowed = total_threads // adjusted_capacity
+                # we need free capacity to be able to scale-up for working targets
+                adjusted_capacity = 1
                 if num_allowed == 0:
                     # presumably this is going to be an extreme use case
                     raise RuntimeError("Capacity initialization error")
                 random.shuffle(tcp_flooders)
                 tcp_flooders, num_flooders = tcp_flooders[:num_allowed], num_allowed
                 force_install = True
-                logger.info(f"{cl.MAGENTA}Обрано {num_flooders} випадкових цілей для атаки.{cl.RESET}")
+                logger.info(f"{cl.MAGENTA}Обрано {num_flooders} цілей для атаки{cl.RESET}")
 
             # adjust settings to avoid situation when we have just a few
             # targets in the config (in this case with default CLI settings you are
             # going to start scaling from 3-15 tasks to 7_500)
             adjusted_capacity = max(
-                initial_capacity,
+                adjusted_capacity,
                 int(SCHEDULER_MIN_INIT_FRACTION * total_threads / num_flooders)
             ) if num_flooders > 1 else total_threads
 

--- a/runner.py
+++ b/runner.py
@@ -207,11 +207,7 @@ async def run_ddos(
                 random.shuffle(tcp_flooders)
                 tcp_flooders, num_flooders = tcp_flooders[:num_allowed], num_allowed
                 force_install = True
-                logger.warning(
-                    f"{cl.MAGENTA}Початкова кількість одночасних атак ({num_init}) перевищує "
-                    f"максимально дозволену параметром -t ({total_threads}). "
-                    f"{cl.YELLOW}Обрано {num_flooders} випадкових цілей для атаки.{cl.RESET}"
-                )
+                logger.info(f"{cl.MAGENTA}Обрано {num_flooders} випадкових цілей для атаки.{cl.RESET}")
 
             # adjust settings to avoid situation when we have just a few
             # targets in the config (in this case with default CLI settings you are

--- a/runner.py
+++ b/runner.py
@@ -300,7 +300,8 @@ async def run_ddos(
                     logger.warning(
                         f"{cl.MAGENTA}Завантажено порожній конфіг - буде використано попередній{cl.RESET}"
                     )
-                elif (changed or force_next):
+
+                if targets and (changed or force_next):
                     force_next = await install_targets(targets)
 
             except asyncio.CancelledError as e:

--- a/runner.py
+++ b/runner.py
@@ -3,10 +3,10 @@ try: import colorama; colorama.init()
 except:raise
 # @formatter:on
 import asyncio
-from functools import partial
 import random
 import sys
 import time
+from functools import partial
 from threading import Event, Thread
 from typing import List, Set, Union
 
@@ -299,18 +299,15 @@ async def run_ddos(
             try:
                 await asyncio.sleep(delay_seconds)
                 targets, changed = await targets_loader.load(resolve=True)
-                if not changed and not force_next:
-                    logger.info(
-                        f"{cl.YELLOW}Перелік цілей не змінився - "
-                        f"чекаємо {delay_seconds} сек до наступної перевірки{cl.RESET}"
-                    )
-                elif not targets:
+
+                if not targets:
                     logger.warning(
-                        f"{cl.MAGENTA}Завантажено порожній конфіг - "
-                        f"буде використано попередній{cl.RESET}"
+                        f"{cl.MAGENTA}Завантажено порожній конфіг - буде використано попередній{cl.RESET}"
                     )
-                else:
+
+                if targets and (changed or force_next):
                     force_next = await install_targets(targets)
+
             except asyncio.CancelledError as e:
                 raise e
             except Exception as exc:

--- a/runner.py
+++ b/runner.py
@@ -202,13 +202,15 @@ async def run_ddos(
 
             if num_init > total_threads:
                 num_allowed = total_threads // adjusted_capacity
-                # we need free capacity to be able to scale-up for working targets
-                adjusted_capacity = 1
                 if num_allowed == 0:
                     # presumably this is going to be an extreme use case
                     raise RuntimeError("Capacity initialization error")
+
+                # we need free capacity to be able to scale-up for working targets
+                adjusted_capacity = 1
                 random.shuffle(tcp_flooders)
-                tcp_flooders, num_flooders = tcp_flooders[:num_allowed], num_allowed
+                tcp_flooders = tcp_flooders[:num_allowed]
+                num_flooders = len(tcp_flooders)
                 force_install = True
                 logger.info(f"{cl.MAGENTA}Обрано {num_flooders} цілей для атаки{cl.RESET}")
 

--- a/src/mhddos.py
+++ b/src/mhddos.py
@@ -175,6 +175,7 @@ class AttackSettings:
 
 
 class AsyncTcpFlood:
+
     BASE_HEADERS = (
         'Accept-Encoding: gzip, deflate, br\r\n'
         'Accept-Language: en-US,en;q=0.9\r\n'
@@ -213,10 +214,15 @@ class AsyncTcpFlood:
             else "GET"
         )
 
+        self._method = method
         self.SENT_FLOOD = getattr(self, method)
 
         self._loop = loop
         self._settings = settings or AttackSettings()
+
+    @property
+    def desc(self) -> Tuple[str, int, str]:
+        return (self._target.host, self._target.port, self._method)
 
     @property
     def is_tls(self):
@@ -662,6 +668,7 @@ class AsyncTcpFlood:
 
 
 class AsyncUdpFlood:
+
     def __init__(
         self,
         target: Tuple[str, int],
@@ -680,7 +687,13 @@ class AsyncUdpFlood:
         self._loop = loop
         self._settings = settings or AttackSettings()
 
+        self._method = method
         self.SENT_FLOOD = getattr(self, method)
+
+    @property
+    def desc(self) -> Tuple[str, int, str]:
+        addr, port = self.target
+        return (addr, port, self.method)
 
     async def run(self) -> bool:
         return await self.SENT_FLOOD()

--- a/src/mhddos.py
+++ b/src/mhddos.py
@@ -692,8 +692,8 @@ class AsyncUdpFlood:
 
     @property
     def desc(self) -> Tuple[str, int, str]:
-        addr, port = self.target
-        return (addr, port, self.method)
+        addr, port = self._target
+        return (addr, port, self._method)
 
     async def run(self) -> bool:
         return await self.SENT_FLOOD()


### PR DESCRIPTION
Instead of just printing out warning message, the system now actually limits the number of simultaneously running tasks by choosing random targets.

The warning message tells what's going on:

```
[23:34:03 - WARNING] Початкова кількість одночасних атак (624) перевищує максимально дозволену параметром -t (10). Обрано 3 випадкових цілей для атаки.
```

In case not all targets were used for the attack, the list is going to be re-selected during the next update cycle even if the list of targets loaded from the config remains the same.

Misc updates:
* list of targets for attack is now gets printed out only when the target is known to be attacked for sure (not when preparing runnables)
* issue with reinstalling tasks when nothing changes introduced [here](https://github.com/porthole-ascend-cinnamon/mhddos_proxy/commit/55c3e61ad56343577c8e557f75842ae731471857) is now fixed