### PR TITLE
fix-issues-117

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM python:3.10-alpine as builder
+FROM --platform=$TARGETPLATFORM python:3.10-alpine as builder
 RUN apk update && apk add --update cargo gcc rust make musl-dev python3-dev libffi-dev openssl-dev
 
 RUN python -m venv /opt/venv
@@ -7,7 +7,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY ./requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-FROM --platform=$BUILDPLATFORM python:3.10-alpine
+FROM --platform=$TARGETPLATFORM python:3.10-alpine
 COPY --from=builder	/opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR mhddos_proxy


### PR DESCRIPTION
aarch64 linux/arm64 image failed to start

It's build but get way more time for it on my MBP 2018.

[+] Building 1246.7s (25/25) FINISHED                                                                                                                                                      

build log 
I use my own dockerhub acc for test 
`docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag rnd49/mhddos_proxy:latest .`
```
[+] Building 1246.7s (25/25) FINISHED                                                                                                                                                      
 => [internal] booting buildkit                                                                                                                                                      11.1s
 => => pulling image moby/buildkit:buildx-stable-1                                                                                                                                   10.2s
 => => creating container buildx_buildkit_laughing_almeida0                                                                                                                           0.8s
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 708B                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 101B                                                                                                                                                     0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/python:3.10-alpine                                                                                                     2.4s
 => [linux/arm64 internal] load metadata for docker.io/library/python:3.10-alpine                                                                                                     2.5s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                                         0.0s
 => [linux/amd64 stage-1 1/4] FROM docker.io/library/python:3.10-alpine@sha256:f4c1b7853b1513eb2f551597e2929b66374ade28465e7d79ac9e099ccecdfeec                                       0.0s
 => => resolve docker.io/library/python:3.10-alpine@sha256:f4c1b7853b1513eb2f551597e2929b66374ade28465e7d79ac9e099ccecdfeec                                                           0.0s
 => [internal] load build context                                                                                                                                                     0.0s
 => => transferring context: 31.30kB                                                                                                                                                  0.0s
 => CACHED [linux/arm64 builder 1/5] FROM docker.io/library/python:3.10-alpine@sha256:f4c1b7853b1513eb2f551597e2929b66374ade28465e7d79ac9e099ccecdfeec                                0.0s
 => => resolve docker.io/library/python:3.10-alpine@sha256:f4c1b7853b1513eb2f551597e2929b66374ade28465e7d79ac9e099ccecdfeec                                                           0.0s
 => CACHED [linux/arm64 builder 2/5] RUN apk update && apk add --update cargo gcc rust make musl-dev python3-dev libffi-dev openssl-dev                                               0.0s
 => CACHED [linux/arm64 builder 3/5] RUN python -m venv /opt/venv                                                                                                                     0.0s
 => CACHED [linux/arm64 builder 4/5] COPY ./requirements.txt .                                                                                                                        0.0s
 => CACHED [linux/amd64 builder 2/5] RUN apk update && apk add --update cargo gcc rust make musl-dev python3-dev libffi-dev openssl-dev                                               0.0s
 => CACHED [linux/amd64 builder 3/5] RUN python -m venv /opt/venv                                                                                                                     0.0s
 => CACHED [linux/amd64 builder 4/5] COPY ./requirements.txt .                                                                                                                        0.0s
 => CACHED [linux/amd64 builder 5/5] RUN pip3 install --no-cache-dir -r requirements.txt                                                                                              0.0s
 => CACHED [linux/amd64 stage-1 2/4] COPY --from=builder /opt/venv /opt/venv                                                                                                          0.0s
 => CACHED [linux/amd64 stage-1 3/4] WORKDIR mhddos_proxy                                                                                                                             0.0s
 => CACHED [linux/amd64 stage-1 4/4] COPY . .                                                                                                                                         0.0s
 => [linux/arm64 builder 5/5] RUN pip3 install --no-cache-dir -r requirements.txt                                                                                                  1207.2s
 => [linux/arm64 stage-1 2/4] COPY --from=builder /opt/venv /opt/venv                                                                                                                 0.4s
 => [linux/arm64 stage-1 3/4] WORKDIR mhddos_proxy                                                                                                                                    0.0s
 => [linux/arm64 stage-1 4/4] COPY . .                                                                                                                                                0.1s
 => exporting to image                                                                                                                                                               24.8s
 => => exporting layers                                                                                                                                                               2.0s
 => => exporting manifest sha256:31a15b05f3ad4d4fbf58a9c1249a48165b331b936f94b68a5562d6fcddf6ebb4                                                                                     0.0s
 => => exporting config sha256:dfeda84df3409c2d88be58d4908ad235fb6846978a92d7880e712ee2446c5182                                                                                       0.0s
 => => exporting manifest sha256:8f8f663d941bcf4fe07d9c17b7df5f34d737451b85beec963aaa1234633f7788                                                                                     0.0s
 => => exporting config sha256:0d99a7ddf2be4d8ffcfaf919bf689d155ba66541c06fd922faa04525ecd2f4e4                                                                                       0.0s
 => => exporting manifest list sha256:1de2acaa467b48568297a6e60f9a79674cceb822cf9177665398aa263bf34cb9                                                                                0.0s
 => => pushing layers                                                                                                                                                                21.4s
 => => pushing manifest for docker.io/rnd49/mhddos_proxy:latest@sha256:1de2acaa467b48568297a6e60f9a79674cceb822cf9177665398aa263bf34cb9                                               1.4s
 => [auth] rnd49/mhddos_proxy:pull,push token for registry-1.docker.io                                                                                                                0.0s
```
Raspberry Pi target run (arm64)

```
 docker run -it --rm --pull always rnd49/mhddos_proxy --vpn --itarmy
latest: Pulling from rnd49/mhddos_proxy
9981e73032c8: Already exists 
55c8fe6b3000: Already exists 
722de16af729: Already exists 
2bc97734257b: Already exists 
818dbd6e0ada: Already exists 
30089c299ab7: Pull complete 
f119d931804e: Pull complete 
ddaeff9a840e: Pull complete 
Digest: sha256:1de2acaa467b48568297a6e60f9a79674cceb822cf9177665398aa263bf34cb9
Status: Downloaded newer image for rnd49/mhddos_proxy:latest
[21:21:12 - INFO] 'uvloop' успішно активований (підвищенна ефективність роботи з мережею)

- Навантаження (кількість потоків) - параметр `-t 5000`, за замовчуванням - 7500
- Статистика у вигляді таблиці або тексту - прапорець `--table` або `--debug`
- Повна документація - https://github.com/porthole-ascend-cinnamon/mhddos_proxy
    
[21:21:12 - INFO] Завантажуємо проксі...
[21:21:14 - INFO] Завантажуємо цілі...
[21:21:14 - INFO] Завантажено конфіг https://gist.githubusercontent.com/ddosukraine2022/f739250dba308a7a2215617b17114be9/raw/mhdos_targets_tcp_v2.txt на 123 цілей
[21:21:15 - WARNING] Ціль news.zarpressa.ru не доступна і не буде атакована
[21:21:15 - WARNING] Ціль nyaganaero.ru не доступна і не буде атакована
[21:21:15 - WARNING] Ціль www.tp-tara.ru не доступна і не буде атакована
[21:21:15 - WARNING] Ціль klintsy.info не доступна і не буде атакована
[21:21:15 - INFO] Запускаємо атаку...
[21:21:15 - INFO] Атакуємо ціль: www.alrosa.aero, Порт: 443, Метод: GET
[21:21:15 - INFO] Атакуємо ціль: www.alrosa.aero, Порт: 443, Метод: STRESS
[21:21:15 - INFO] Атакуємо ціль: cdnv.nashstore.ru, Порт: 443, Метод: GET
[21:21:15 - INFO] Атакуємо ціль: cdnv.nashstore.ru, Порт: 443, Метод: STRESS
[21:21:15 - INFO] Атакуємо ціль: avia.gazprom.ru, Порт: 443, Метод: GET
[21:21:15 - INFO] Атакуємо ціль: avia.gazprom.ru, Порт: 443, Метод: STRESS
```

MBP target run (amd64)
```
docker run -it --rm --pull always rnd49/mhddos_proxy --vpn --itarmy
latest: Pulling from rnd49/mhddos_proxy
df9b9388f04a: Pull complete 
a1ef3e6b7a02: Pull complete 
7a687728470e: Pull complete 
4ecf30de1710: Pull complete 
c3b27164aa0c: Pull complete 
4e126dbd73e2: Pull complete 
2a0cfb2afd1e: Pull complete 
bcb9f0402e41: Pull complete 
Digest: sha256:1de2acaa467b48568297a6e60f9a79674cceb822cf9177665398aa263bf34cb9
Status: Downloaded newer image for rnd49/mhddos_proxy:latest
[21:37:57 - INFO] 'uvloop' успішно активований (підвищенна ефективність роботи з мережею)

- Навантаження (кількість потоків) - параметр `-t 5000`, за замовчуванням - 7500
- Статистика у вигляді таблиці або тексту - прапорець `--table` або `--debug`
- Повна документація - https://github.com/porthole-ascend-cinnamon/mhddos_proxy
    
[21:37:57 - INFO] Завантажуємо проксі...
[21:37:57 - INFO] Завантажуємо цілі...
[21:37:57 - INFO] Завантажено конфіг https://gist.githubusercontent.com/ddosukraine2022/f739250dba308a7a2215617b17114be9/raw/mhdos_targets_tcp_v2.txt на 123 цілей
[21:37:57 - WARNING] Ціль nyaganaero.ru не доступна і не буде атакована
[21:37:57 - WARNING] Ціль news.zarpressa.ru не доступна і не буде атакована
[21:37:57 - WARNING] Ціль www.tp-tara.ru не доступна і не буде атакована
[21:37:58 - WARNING] Ціль klintsy.info не доступна і не буде атакована
[21:37:58 - INFO] Запускаємо атаку...
[21:37:58 - INFO] Атакуємо ціль: www.alrosa.aero, Порт: 443, Метод: GET
[21:37:58 - INFO] Атакуємо ціль: www.alrosa.aero, Порт: 443, Метод: STRESS
[21:37:58 - INFO] Атакуємо ціль: cdnv.nashstore.ru, Порт: 443, Метод: GET
```