### PR TITLE
arm build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM --platform=$TARGETPLATFORM python:3.10-alpine as builder
-RUN apk update && apk add --update cargo gcc rust make musl-dev python3-dev libffi-dev openssl-dev
+FROM --platform=$TARGETPLATFORM python:3.10-slim as builder
 
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY ./requirements.txt .
 RUN python3 -m pip install --no-cache-dir wheel
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+RUN python3 -m pip install --no-cache-dir --only-binary=:all: -r requirements.txt
 
-FROM --platform=$TARGETPLATFORM python:3.10-alpine
+FROM --platform=$TARGETPLATFORM python:3.10-slim
 COPY --from=builder	/opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR mhddos_proxy


### PR DESCRIPTION
proposal

If avoid arm/v7 build. (does it really need 32 bit targets?) 
And use slim/buster etc. (not alpine) base image.
Build time can be significantly decreased. (return to previous metrics) but solve issue with arm64 arch. 
It's achieved by using precompiled binaries.

`docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag rnd49/mhddos_proxy:latest .`
```
[+] Building 113.5s (24/24) FINISHED                                                                                                                                                       
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 87B                                                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 507B                                                                                                                                                  0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/python:3.10-slim                                                                                                       2.1s
 => [linux/arm64 internal] load metadata for docker.io/library/python:3.10-slim                                                                                                       2.1s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                                         0.0s
 => CACHED [linux/arm64 builder 1/5] FROM docker.io/library/python:3.10-slim@sha256:54956d6c929405ff651516d5ebbc204203a6415c9d2757aaddcde35be680431e                                  0.0s
 => => resolve docker.io/library/python:3.10-slim@sha256:54956d6c929405ff651516d5ebbc204203a6415c9d2757aaddcde35be680431e                                                             0.0s
 => [internal] load build context                                                                                                                                                     0.1s
 => => transferring context: 540.15kB                                                                                                                                                 0.1s
 => CACHED [linux/amd64 builder 1/5] FROM docker.io/library/python:3.10-slim@sha256:54956d6c929405ff651516d5ebbc204203a6415c9d2757aaddcde35be680431e                                  0.0s
 => => resolve docker.io/library/python:3.10-slim@sha256:54956d6c929405ff651516d5ebbc204203a6415c9d2757aaddcde35be680431e                                                             0.0s
 => [linux/arm64 builder 2/5] RUN python3 -m venv /opt/venv                                                                                                                          38.8s
 => [linux/amd64 builder 2/5] RUN python3 -m venv /opt/venv                                                                                                                           3.6s
 => [linux/amd64 builder 3/5] COPY ./requirements.txt .                                                                                                                               0.0s
 => [linux/amd64 builder 4/5] RUN python3 -m pip install --no-cache-dir wheel                                                                                                         1.1s
 => [linux/amd64 builder 5/5] RUN python3 -m pip install --no-cache-dir --only-binary=:all: -r requirements.txt                                                                       8.5s 
 => [linux/amd64 stage-1 2/4] COPY --from=builder /opt/venv /opt/venv                                                                                                                 0.5s 
 => [linux/amd64 stage-1 3/4] WORKDIR mhddos_proxy                                                                                                                                    0.0s 
 => [linux/amd64 stage-1 4/4] COPY . .                                                                                                                                                0.1s
 => [linux/arm64 builder 3/5] COPY ./requirements.txt .                                                                                                                               0.0s
 => [linux/arm64 builder 4/5] RUN python3 -m pip install --no-cache-dir wheel                                                                                                         6.9s
 => [linux/arm64 builder 5/5] RUN python3 -m pip install --no-cache-dir --only-binary=:all: -r requirements.txt                                                                      41.7s
 => [linux/arm64 stage-1 2/4] COPY --from=builder /opt/venv /opt/venv                                                                                                                 0.5s
 => [linux/arm64 stage-1 3/4] WORKDIR mhddos_proxy                                                                                                                                    0.0s
 => [linux/arm64 stage-1 4/4] COPY . .                                                                                                                                                0.1s
 => exporting to image                                                                                                                                                               23.1s
 => => exporting layers                                                                                                                                                               2.6s
 => => exporting manifest sha256:5c0e9bedefbdca0ebd8e2047e47902be64d6c85ceba513eb6804f11db906e14f                                                                                     0.0s
 => => exporting config sha256:6879cc5d5782eaf6e67c20f8e2f0a8ccdf731e85124982b8d94d0e2b214ddee4                                                                                       0.0s
 => => exporting manifest sha256:9827da2bfec10bd52abee967cd3da0b4d5c91157e03578c01ec786465594f91a                                                                                     0.0s
 => => exporting config sha256:8fd90b6899b2afbbbfc51757e67c315ae47a92492a8e3affbee7f0da37818667                                                                                       0.0s
 => => exporting manifest list sha256:ba1a61b055b0d8c2ae3badb963b2712ba9aa4a036f2460d6075b72cf454e5c33                                                                                0.0s
 => => pushing layers                                                                                                                                                                19.1s
 => => pushing manifest for docker.io/rnd49/mhddos_proxy:latest@sha256:ba1a61b055b0d8c2ae3badb963b2712ba9aa4a036f2460d6075b72cf454e5c33                                               1.3s
 => [auth] rnd49/mhddos_proxy:pull,push token for registry-1.docker.io 
```