### PR TITLE
Add link to Telegram notifications setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [Приклад запуску через docker на OpenWRT](https://youtu.be/MlL6fuDcWlI)
 - [VPN](https://auto-ddos.notion.site/VPN-5e45e0aadccc449e83fea45d56385b54)
 - [Docker-image](https://github.com/alexnest-ua/auto_mhddos_alexnest/tree/docker), який запускає одночасно mhddos_proxy та [proxy_finder](https://github.com/porthole-ascend-cinnamon/proxy_finder) (для Linux / Mac додайте sudo на початку):
+- [Налаштування з нотифікаціями у Телеграм](https://github.com/sadviq99/mhddos_proxy-setup)
 
 ### 6. CLI
 


### PR DESCRIPTION
The mhddos_proxy tool is great! The only missing part that stops us from the "set it up and forget" approach is worrying if everything is working correctly. The instruction I'm referring to is solving this problem by sending Telegram notifications every X hours (configurable) with the status of attacks retrieved from the mhddos_proxy logs. 

<img width="314" alt="notifications" src="https://user-images.githubusercontent.com/102911721/170146145-15c6e995-ac53-4f1f-b3a4-1bb09c347cc0.png">

The parsing script will not reside on the user's servers, so in case of the output changes the script needs to be updated only once, then it will be automatically fetched on the next execution time.

I hope people will benefit from this setup option. 