### PR TITLE
survive git inaccessibility #146

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -26,19 +26,23 @@ function stop_script() {
   fi
 }
 
+function gitsafe() {
+    git "$@" || echo git command failed, simulating success \("$@"\) >&2
+}
+
 function update_script() {
-    git reset -q --hard
-    git checkout -q $BRANCH
-    git pull -q
+    gitsafe reset -q --hard
+    gitsafe checkout -q $BRANCH
+    gitsafe pull -q
     $PYTHON -m pip install -q -r requirements.txt
 }
 
 while true
 do
 
-  git fetch -q origin $BRANCH
+  gitsafe fetch -q origin $BRANCH
 
-  if [ -n "$(git diff --name-only origin/$BRANCH)" ]
+  if [ -n "$(gitsafe diff --name-only origin/$BRANCH)" ]
   then
     echo -e "\n${GREEN}[$(date +"%d-%m-%Y %T")] - New version available, updating the script!${RESET}\n"
     stop_script


### PR DESCRIPTION
For #146.

I prepared gitsafe function and replaced with it the plain git invocations. gitsafe simulates successful run of git, but prints a message on stderr.

I tested following cases:
1. Updated the repo and saw the runner updates itself without intervention.
2. Changed the repo url to invalid port and saw the runner passes through it (update from repo impossible in such case of course).

The only potential problem I see with this change is that permanent problem with git access may be harder to notice. An error message will appear, but the script will continue running.