### PR TITLE
Do not abort on StopIteration

### DIFF
--- a/src/proto.py
+++ b/src/proto.py
@@ -203,7 +203,7 @@ class FloodIO(asyncio.Protocol):
             else:
                 raise ValueError(f"Unknown flood opcode {op}")
         except StopIteration:
-            self._transport.abort()
+            self._transport.close()
             self._transport = None
 
     def _handle_cancellation(self, on_close):


### PR DESCRIPTION
As in this case we lose (potentially) entire high watermark buffer of writes.

To be honest, we rarely get to this point as it takes long time to push 2000 writes though a proxy connection.