### PR TITLE
break retry loop when unable to start runner.py for n times

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -65,6 +65,7 @@ do
 
   fi
 
+  retry_count=0
   while [ -z "$PID" ]
   do
 
@@ -81,6 +82,12 @@ do
       PID=""
       echo -e "\n${RED}Error starting - retry in 30 seconds! Ctrl+C to exit${RESET}"
       sleep 30
+      retry_count=$(( $retry_count + 1 ))
+      if [[ $(( $retry_count >= 10 )) == 1 ]]
+      then
+        # Maybe runner.py is permanently broken? Then we need to break out and do the update.
+        break
+      fi
     fi
 
   done


### PR DESCRIPTION
This is a workaround for #170. After n (say 10) unsuccessful retries of spawning runner.py, break the loop and allow the updater code to work.

I tested it spoiling runner.py and fixing it in repo after runner.sh falls into the loop. It was able to recover.